### PR TITLE
Introduce applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /tests/*.retry
+/lookup_plugins/*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Handle application
 
 ## [1.0.0] - 2016-12-29
-
 ### Added
 - Install docker

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ help:
 # Dev #
 #######
 
+## Dev - Wheezy
 dev@wheezy: DEBIAN_DISTRIBUTION = wheezy
 dev@wheezy: dev
 
+## Dev - Jessie
 dev@jessie: DEBIAN_DISTRIBUTION = jessie
 dev@jessie: dev
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,8 @@
 # Install
 manala_docker_install_packages:
   - docker-engine
+
+# Applications
+manala_docker_applications_template: ~
+manala_docker_applications_dir:      /usr/local/bin
+manala_docker_applications:          []

--- a/lookup_plugins/manala_docker_applications.py
+++ b/lookup_plugins/manala_docker_applications.py
@@ -1,0 +1,74 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+
+        results = []
+
+        # Patterns
+        patterns = terms[1]
+
+        itemDefault = {
+            'version': 'latest'
+        }
+
+        print(self._flatten(terms[0]))
+        print(patterns)
+
+        for term in self._flatten(terms[0]):
+
+            items = []
+
+            # Short syntax
+            if isinstance(term, basestring):
+                item = itemDefault.copy()
+
+                # Pattern
+                if not patterns.has_key(term.split('@')[0]):
+                    print(term.split('@')[0])
+                    raise AnsibleError('Unknown pattern')
+
+                item.update(patterns.get(term.split('@')[0]))
+
+                # Version
+                if len(term.split('@')) > 1:
+                    item.update({
+                        'version': term.split('@')[1]
+                    })
+            else:
+
+                # Must be a dict
+                if not isinstance(term, dict):
+                    raise AnsibleError('Expect a dict')
+
+                # Check index key
+                if not term.has_key('application'):
+                    raise AnsibleError('Expect "application" key')
+
+                if not term.has_key('image'):
+                    raise AnsibleError('Expect "image" key')
+
+                item = itemDefault.copy()
+
+                item.update(term)
+
+            items.append(item)
+
+            # Merge by index key
+            for item in items:
+                itemFound = False
+                for i, result in enumerate(results):
+                    if result['application'] == item['application']:
+                        results[i] = item
+                        itemFound = True
+                        break
+
+                if not itemFound:
+                    results.append(item)
+
+        return results

--- a/lookup_plugins/manala_docker_applications.py
+++ b/lookup_plugins/manala_docker_applications.py
@@ -17,9 +17,6 @@ class LookupModule(LookupBase):
             'version': 'latest'
         }
 
-        print(self._flatten(terms[0]))
-        print(patterns)
-
         for term in self._flatten(terms[0]):
 
             items = []
@@ -30,7 +27,6 @@ class LookupModule(LookupBase):
 
                 # Pattern
                 if not patterns.has_key(term.split('@')[0]):
-                    print(term.split('@')[0])
                     raise AnsibleError('Unknown pattern')
 
                 item.update(patterns.get(term.split('@')[0]))

--- a/tasks/applications.yml
+++ b/tasks/applications.yml
@@ -1,0 +1,10 @@
+---
+
+- name: applications > Templates
+  template:
+    src:  "{{ item.template|default(manala_docker_applications_template|ternary(manala_docker_applications_template, 'applications/default.j2')) }}"
+    dest: "{{ manala_docker_applications_dir }}/{{ item.application }}"
+    mode: 0755
+  with_manala_docker_applications:
+    - "{{ manala_docker_applications }}"
+    - "{{ manala_docker_applications_patterns }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,3 +11,8 @@
     - manala_docker
     - manala_docker.services
     - manala.services
+
+# Applications
+- include: applications.yml
+  tags:
+    - manala_docker

--- a/templates/applications/default.j2
+++ b/templates/applications/default.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+DIR=`pwd`
+
+docker run --rm --volume ${DIR}:${DIR} --workdir ${DIR} {{ item.image }}:{{ item.version }} {{ item.application }} "$@"

--- a/templates/applications/interactive.j2
+++ b/templates/applications/interactive.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+DIR=`pwd`
+
+docker run --rm --interactive --volume ${DIR}:${DIR} --workdir ${DIR} {{ item.image }}:{{ item.version }} {{ item.application }} "$@"

--- a/templates/applications/interactive_tty.j2
+++ b/templates/applications/interactive_tty.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+DIR=`pwd`
+
+docker run --rm --interactive --tty --volume ${DIR}:${DIR} --workdir ${DIR} {{ item.image }}:{{ item.version }} {{ item.application }} "$@"

--- a/tests/030_applications.goss.yml
+++ b/tests/030_applications.goss.yml
@@ -1,0 +1,9 @@
+---
+
+command:
+  stylelint --version:
+    exit-status: 0
+    timeout:     600000
+  eslint --version:
+    exit-status: 0
+    timeout:     600000

--- a/tests/030_applications.goss.yml
+++ b/tests/030_applications.goss.yml
@@ -4,6 +4,3 @@ command:
   stylelint --version:
     exit-status: 0
     timeout:     600000
-  eslint --version:
-    exit-status: 0
-    timeout:     600000

--- a/tests/030_applications.yml
+++ b/tests/030_applications.yml
@@ -1,0 +1,18 @@
+---
+
+- name: "{{ test }}"
+  hosts: all
+  vars:
+    manala_docker_applications:
+      - application: stylelint
+        image:       manala/lint-css
+      - manala/eslint@0
+  pre_tasks:
+    - include: pre_tasks/docker.yml
+    - include: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+  roles:
+    - manala.docker
+  post_tasks:
+    - name: Goss
+      command: goss --gossfile {{ test }}.goss.yml validate

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,24 @@
+---
+
+# Applications
+manala_docker_applications_patterns:
+  manala/eslint:
+    application: eslint
+    image:       manala/lint-js
+    template:    applications/interactive_tty.j2
+  manala/stylelint:
+    application: stylelint
+    image:       manala/lint-css
+    template:    applications/interactive_tty.j2
+  manala/stylefmt:
+    application: stylefmt
+    image:       manala/lint-css
+    template:    applications/interactive_tty.j2
+  manala/php-cs-fixer:
+    application: php-cs-fixer
+    image:       manala/lint-php
+    template:    applications/interactive.j2
+  manala/security-checker:
+    application: security-checker
+    image:       manala/security-php
+    template:    applications/interactive_tty.j2


### PR DESCRIPTION
Handle simple shell scripts - in a templated way - to run dockerized applications.

For instance
```
manala_docker_applications:
  - application: stylelint
    image:       manala/lint-css
  - manala/eslint
```

Tada, you got /usr/local/bin/stylelint and /usr/local/bin/eslint, ready to run stylelint and eslint using their related manala docker images